### PR TITLE
Enable recursive globbing in project doctor script

### DIFF
--- a/project-doctor.sh
+++ b/project-doctor.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# Enable recursive globbing so '**' patterns traverse directories
+# Nullglob prevents unmatched globs from expanding to literal strings
+shopt -s globstar nullglob
+
 # Colors
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
## Summary
- enable recursive glob expansion in project-doctor.sh
- document globstar/nullglob behavior

## Testing
- `bash project-doctor.sh >/tmp/doctor.log` *(aborted: excessive output)*

------
https://chatgpt.com/codex/tasks/task_e_6856526e6d608321aa7477cb415e91ed