### PR TITLE
Enable globstar in doctor web checks

### DIFF
--- a/project-doctor.sh
+++ b/project-doctor.sh
@@ -102,12 +102,14 @@ run_python_checks() {
 }
 
 run_web_checks() {
-    echo -e "\n${BLUE}========== WEB QUALITY ==========${NC}"
-    echo -e "${YELLOW}HTML validation...${NC}"
-    npx --yes htmlhint **/*.html || true
+  echo -e "\n${BLUE}========== WEB QUALITY ==========${NC}"
+  echo -e "${YELLOW}HTML validation...${NC}"
+  shopt -s globstar
+  npx --yes htmlhint **/*.html || true
 
-    echo -e "\n${YELLOW}CSS linting...${NC}"
-    npx --yes csslint **/*.css || true
+  echo -e "\n${YELLOW}CSS linting...${NC}"
+  shopt -s globstar
+  npx --yes csslint **/*.css || true
 }
 
 # Main execution


### PR DESCRIPTION
## Summary
- enable globstar before htmlhint and csslint

## Testing
- `bash project-doctor.sh >/tmp/doctor.log && tail -n 20 /tmp/doctor.log`

------
https://chatgpt.com/codex/tasks/task_e_6856669b926883218ea14fd7639bfe2e