### PR TITLE
Add domain placeholders for canonical links

### DIFF
--- a/DEPLOYMENT-README.md
+++ b/DEPLOYMENT-README.md
@@ -19,6 +19,8 @@
    ```bash
    # Replace URL placeholder in sitemap.xml
    sed -i 's/SITE_URL_PLACEHOLDER/https://yourdomain.com/g' sitemap.xml
+   # Update placeholders in index.html canonical and social meta tags
+   sed -i 's|SITE_URL_PLACEHOLDER|https://yourdomain.com|g' index.html
    ```
 
 3. **Web Server Configuration**

--- a/index.html
+++ b/index.html
@@ -17,21 +17,21 @@
     <meta name="keywords" content="free online tools, text tools, SEO tools, calculators, converters, developer tools, generators, word counter, JSON formatter, password generator">
     <meta name="author" content="Free Tools Hub">
     <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
-    <link rel="canonical" href="https://zea6oz30ga.space.minimax.io/">
+    <link rel="canonical" href="SITE_URL_PLACEHOLDER/">
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://zea6oz30ga.space.minimax.io/">
+    <meta property="og:url" content="SITE_URL_PLACEHOLDER/">
     <meta property="og:title" content="Free Tools Hub - 60+ Professional Online Tools">
     <meta property="og:description" content="Access 60+ free online tools including text analyzers, SEO utilities, calculators, converters, and developer tools.">
-    <meta property="og:image" content="https://zea6oz30ga.space.minimax.io/images/og-image.jpg">
+    <meta property="og:image" content="SITE_URL_PLACEHOLDER/images/og-image.jpg">
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://zea6oz30ga.space.minimax.io/">
+    <meta property="twitter:url" content="SITE_URL_PLACEHOLDER/">
     <meta property="twitter:title" content="Free Tools Hub - 60+ Professional Online Tools">
     <meta property="twitter:description" content="Access 60+ free online tools including text analyzers, SEO utilities, calculators, converters, and developer tools.">
-    <meta property="twitter:image" content="https://zea6oz30ga.space.minimax.io/images/twitter-image.jpg">
+    <meta property="twitter:image" content="SITE_URL_PLACEHOLDER/images/twitter-image.jpg">
     
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico">


### PR DESCRIPTION
## Summary
- reference a placeholder domain in canonical and social media meta tags
- explain replacing those placeholders in deployment steps

## Testing
- `npm install`
- `./project-doctor.sh` *(fails: RangeError in csslint output but completes)*

------
https://chatgpt.com/codex/tasks/task_e_685677fffa4483218e56856a6bdcb205