### PR TITLE
Skip vendor files in lint checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ chmod +x project-doctor.sh
 ./project-doctor.sh
 ```
 
-The script lints HTML/CSS assets and optionally runs Python checks. Review the output for any warnings.
+The script lints HTML/CSS assets (ignoring third-party files in `vendor/`) and optionally runs Python checks. Review the output for any warnings.

--- a/project-doctor.sh
+++ b/project-doctor.sh
@@ -104,12 +104,12 @@ run_python_checks() {
 run_web_checks() {
   echo -e "\n${BLUE}========== WEB QUALITY ==========${NC}"
   echo -e "${YELLOW}HTML validation...${NC}"
-  shopt -s globstar
-  npx --no-install htmlhint **/*.html || true
+  html_files=$(find . -path './vendor' -prune -o -name '*.html' -print)
+  npx --no-install htmlhint ${html_files} || true
 
   echo -e "\n${YELLOW}CSS linting...${NC}"
-  shopt -s globstar
-  npx --no-install csslint **/*.css || true
+  css_files=$(find . -path './vendor' -prune -o -name '*.css' -print)
+  npx --no-install csslint ${css_files} || true
 }
 
 # Main execution


### PR DESCRIPTION
## Summary
- avoid linting vendor code in project-doctor's web checks
- mention vendor directory exclusion in README

## Testing
- `npm install`
- `./project-doctor.sh`

------
https://chatgpt.com/codex/tasks/task_e_68567bd6bb3c83219a1eadbc61de6b15