### PR TITLE
Add lint config files

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,5 @@
+{
+  "exclude-list": "vendor/",
+  "errors": "import,duplicate-properties,known-properties,empty-rules",
+  "ignore": "adjoining-classes,box-model,ids,outline-none,qualified-headings"
+}

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,11 @@
+{
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": false,
+  "tagname-lowercase": true,
+  "tag-pair": false,
+  "spec-char-escape": false,
+  "id-class-value": "dash",
+  "img-alt-require": true,
+  "space-tab-mixed-disabled": true
+}

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ chmod +x project-doctor.sh
 ```
 
 The script lints HTML/CSS assets (ignoring third-party files in `vendor/`) and optionally runs Python checks. Review the output for any warnings.
+Custom lint rules are stored in `.htmlhintrc` and `.csslintrc` at the project root.


### PR DESCRIPTION
## Summary
- add `.htmlhintrc` ignoring `spec-char-escape` and `tag-pair`
- configure `.csslintrc` with sensible defaults and vendor exclusion
- mention config files in the README project doctor instructions

## Testing
- `npm install`
- `./project-doctor.sh`

------
https://chatgpt.com/codex/tasks/task_e_68567cd60a908321a13de499377f8daa