### PR TITLE
Add sitemap generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ The script automatically installs missing Node dependencies if needed.
 
 The script lints HTML/CSS assets (ignoring third-party files in `vendor/`) and optionally runs Python checks. Review the output for any warnings.
 Custom lint rules are stored in `.htmlhintrc` and `.csslintrc` at the project root.
+
+## Sitemap Generation
+
+Run `node scripts/generate-sitemap.js` after adding or updating tools. This script reads `data/tools-config.json` and rewrites `sitemap.xml` with a `<url>` entry for each tool. Validate the result with `xmllint --noout sitemap.xml`.

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const configPath = path.join(root, 'data', 'tools-config.json');
+const sitemapPath = path.join(root, 'sitemap.xml');
+
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+const tools = config.tools || [];
+
+const existing = fs.readFileSync(sitemapPath, 'utf8');
+const marker = '<!-- Tool pages -->';
+const idx = existing.indexOf(marker);
+if (idx === -1) {
+  throw new Error('Marker not found in sitemap');
+}
+
+const header = existing.substring(0, idx + marker.length);
+const footer = '\n</urlset>\n';
+const lastmod = '2025-06-20';
+
+const toolEntries = tools.map(t =>
+  `    <url><loc>https://SITE_URL_PLACEHOLDER/tools/${t.id}/</loc><lastmod>${lastmod}</lastmod><priority>0.8</priority></url>`
+).join('\n');
+
+const newContent = header + '\n' + toolEntries + '\n' + footer;
+fs.writeFileSync(sitemapPath, newContent);
+console.log('Sitemap regenerated with', tools.length, 'tools');

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -31,11 +31,64 @@
         <priority>0.5</priority>
     </url>
     <!-- Tool pages -->
-    <url><loc>https://SITE_URL_PLACEHOLDER/tools/slug-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
-    <url><loc>https://SITE_URL_PLACEHOLDER/tools/text-to-speech/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/age-calculator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/api-key-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/avatar-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/barcode-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/base64-encoder-decoder/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/bmi-calculator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/character-counter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/code-beautifier/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/color-palette-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/color-picker/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/css-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/css-minifier/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/csv-to-json/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/currency-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/date-format-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/email-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/fake-data-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/favicon-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/gradient-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/hash-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/hex-rgb-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
     <url><loc>https://SITE_URL_PLACEHOLDER/tools/html-css-js-beautifier/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
-    <url><loc>https://SITE_URL_PLACEHOLDER/tools/uuid-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
-    <url><loc>https://SITE_URL_PLACEHOLDER/tools/meta-tag-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
-    <url><loc>https://SITE_URL_PLACEHOLDER/tools/qr-code-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
     <url><loc>https://SITE_URL_PLACEHOLDER/tools/html-encoder-decoder/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/html-minifier/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/icon-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/image-placeholder-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/image-resizer/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/json-formatter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/json-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/keyword-density-checker/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/logo-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/lorem-ipsum-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/markdown-to-html/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/meta-tag-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/name-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/number-base-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/password-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/pdf-to-text/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/percentage-calculator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/qr-code-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/random-number-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/robots-txt-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/roman-numeral-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/seo-analyzer/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/serp-preview/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/sitemap-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/slug-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/text-case-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/text-to-speech/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/timestamp-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/timezone-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/unicode-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/unit-converter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/url-encoder-decoder/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/uuid-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/wifi-qr-generator/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/word-counter/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/xml-to-json/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+    <url><loc>https://SITE_URL_PLACEHOLDER/tools/yaml-to-json/</loc><lastmod>2025-06-20</lastmod><priority>0.8</priority></url>
+
 </urlset>


### PR DESCRIPTION
## Summary
- add a Node script to rebuild `sitemap.xml` from `tools-config.json`
- regenerate sitemap listing all tool pages
- document sitemap generation in the README

## Testing
- `node scripts/generate-sitemap.js`
- `xmllint --noout sitemap.xml`
- `./project-doctor.sh`

------
https://chatgpt.com/codex/tasks/task_e_68568a07e88c832195b1df4fd538fb72