### PR TITLE
Update reading time for zero words

### DIFF
--- a/tools/character-counter/index.html
+++ b/tools/character-counter/index.html
@@ -677,8 +677,9 @@
                 
                 Object.entries(readingSpeeds).forEach(([speed, wpm]) => {
                     const minutes = Math.ceil(wordCount / wpm);
-                    const timeText = minutes < 1 ? '< 1 min' : 
-                                   minutes === 1 ? '1 min' : 
+                    const timeText = wordCount === 0 ? '0 min' :
+                                   minutes < 1 ? '< 1 min' :
+                                   minutes === 1 ? '1 min' :
                                    `${minutes} min`;
                     document.getElementById(`reading-${speed}`).textContent = timeText;
                 });

--- a/tools/word-counter/script.js
+++ b/tools/word-counter/script.js
@@ -257,8 +257,11 @@ class WordCounter {
         // Average reading speed: 200-250 words per minute
         const wordsPerMinute = 225;
         const minutes = wordCount / wordsPerMinute;
-        
-        if (minutes < 1) {
+
+        // Show "0 min" when there is no text
+        if (wordCount === 0) {
+            return '0 min';
+        } else if (minutes < 1) {
             return '< 1 min';
         } else if (minutes < 60) {
             return `${Math.round(minutes)} min`;
@@ -273,8 +276,11 @@ class WordCounter {
         // Average speaking speed: 150-160 words per minute
         const wordsPerMinute = 155;
         const minutes = wordCount / wordsPerMinute;
-        
-        if (minutes < 1) {
+
+        // Show "0 min" when there is no text
+        if (wordCount === 0) {
+            return '0 min';
+        } else if (minutes < 1) {
             return '< 1 min';
         } else if (minutes < 60) {
             return `${Math.round(minutes)} min`;


### PR DESCRIPTION
## Summary
- handle zero-word case for reading and speaking times
- keep "0 min" display in Character Counter

## Testing
- `bash project-doctor.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856a98985f883218fed1932b408d9f5