### PR TITLE
Fix console error when missing copy stats button

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ The Word Counter tool now guards optional UI elements before wiring events.
 Listeners for goal inputs, undo/redo, and keyword-density toggles are only
 registered when the corresponding elements exist. Updates to goal progress or
 keyword density are likewise skipped if their elements are missing. These
-safeguards prevent console errors when the feature markup is omitted.
+safeguards prevent console errors when the feature markup is omitted. The
+copy statistics button handler now checks for `.copy-stats-btn` before
+registering its event listener to avoid errors when the button is absent.
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/tools/word-counter/script.js
+++ b/tools/word-counter/script.js
@@ -38,7 +38,8 @@ class WordCounter {
         // Action buttons
         document.querySelector('.clear-btn').addEventListener('click', () => this.clearText());
         document.querySelector('.copy-btn').addEventListener('click', () => this.copyText());
-        document.querySelector('.copy-stats-btn').addEventListener('click', () => this.copyStats());
+        const copyStatsBtn = document.querySelector('.copy-stats-btn');
+        if (copyStatsBtn) copyStatsBtn.addEventListener('click', () => this.copyStats());
         document.querySelector('.download-btn').addEventListener('click', () => this.downloadText());
 
         // File upload
@@ -111,10 +112,14 @@ class WordCounter {
         window.addEventListener('beforeunload', () => this.saveToLocalStorage());
 
         // Text formatting buttons
-        document.getElementById('uppercase-btn').addEventListener('click', () => this.transformText('uppercase'));
-        document.getElementById('lowercase-btn').addEventListener('click', () => this.transformText('lowercase'));
-        document.getElementById('sentence-case-btn').addEventListener('click', () => this.transformText('sentence'));
-        document.getElementById('remove-extra-spaces-btn').addEventListener('click', () => this.transformText('spaces'));
+        const uppercaseBtn = document.getElementById('uppercase-btn');
+        if (uppercaseBtn) uppercaseBtn.addEventListener('click', () => this.transformText('uppercase'));
+        const lowercaseBtn = document.getElementById('lowercase-btn');
+        if (lowercaseBtn) lowercaseBtn.addEventListener('click', () => this.transformText('lowercase'));
+        const sentenceCaseBtn = document.getElementById('sentence-case-btn');
+        if (sentenceCaseBtn) sentenceCaseBtn.addEventListener('click', () => this.transformText('sentence'));
+        const removeSpacesBtn = document.getElementById('remove-extra-spaces-btn');
+        if (removeSpacesBtn) removeSpacesBtn.addEventListener('click', () => this.transformText('spaces'));
 
         // History navigation
         const undoBtn = document.getElementById('undo-btn');


### PR DESCRIPTION
## Summary
- guard the optional `.copy-stats-btn` element before wiring its click handler
- check text transform buttons exist before attaching events
- document word counter update

## Testing
- `./project-doctor.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856aee531448321adcd729a28c0b1dd