### PR TITLE
Add npm lint commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ Python steps are skipped automatically if the repository contains no Python code
 npm install
 chmod +x project-doctor.sh
 ./project-doctor.sh
+# Quick lint only
+npm run lint
 ```
+
+Use `npm run lint` when you only need to validate HTML and CSS without running
+the full doctor script.
 
 The script automatically installs missing Node dependencies if needed.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "free-tools-hub",
   "private": true,
+  "scripts": {
+    "lint:html": "sh -c \"npx --no-install htmlhint $(find . -path './vendor' -prune -o -name '*.html' -print | tr '\n' ' ')\"",
+    "lint:css": "sh -c \"npx --no-install csslint $(find . -path './vendor' -prune -o -name '*.css' -print | tr '\n' ' ')\"",
+    "lint": "npm run lint:html && npm run lint:css"
+  },
   "devDependencies": {
     "csslint": "^1.0.5",
     "htmlhint": "^1.6.3"


### PR DESCRIPTION
## Summary
- add lint:html and lint:css scripts mirroring project-doctor.sh patterns
- add aggregate lint script
- document npm run lint as a quick doctor alternative

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856b33076ac8321b6810e6c3e60fd2f