### PR TITLE
Delete barcode script_backup.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ safeguards prevent console errors when the feature markup is omitted. The
 copy statistics button handler now checks for `.copy-stats-btn` before
 registering its event listener to avoid errors when the button is absent.
 
+## Housekeeping
+
+Removed unused `script_backup.js` from the barcode generator tool.
+
+
 ## Testing
 
 Run `npm test` to execute the Mocha test suite. Install dependencies first with

--- a/tools/barcode-generator/script_backup.js
+++ b/tools/barcode-generator/script_backup.js
@@ -1,1 +1,0 @@
-// Backup of current script


### PR DESCRIPTION
## Summary
- remove leftover script_backup.js from barcode generator tool
- add housekeeping note about the deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856b7b68f0c8321a5bf097487aa5151