### PR TITLE
Fix duplicate script tags across tools

### DIFF
--- a/VERIFICATION_NOTES.md
+++ b/VERIFICATION_NOTES.md
@@ -48,4 +48,7 @@ The verification script may show "missing tools" due to:
 - Appended newline to data/tools-config.json for consistent formatting and to enforce the rule that JSON files end with a newline at EOF
 - Removed malformed <style> block from timezone converter page to ensure valid HTML.
 - Updated `.csslintrc` to remove `known-properties` from the CSS errors list, allowing custom properties like `gap` and `backdrop-filter`
+- Removed duplicate `<script src="script.js">` tags from all tool pages
+  and added a single deferred script tag before closing `</body>`
+  (verified by running `grep` after automated update)
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -18,7 +18,7 @@ describe('Tool configuration', function() {
     it(`tool ${tool.id} includes script.js script tag`, function() {
       expect(fs.existsSync(indexPath)).to.be.true;
       const content = fs.readFileSync(indexPath, 'utf8');
-      expect(content.includes('<script src="script.js"></script>')).to.be.true;
+      expect(content.includes('<script src="script.js"')).to.be.true;
     });
   });
 });

--- a/tools/age-calculator/index.html
+++ b/tools/age-calculator/index.html
@@ -424,8 +424,7 @@
     
     <!-- Scripts -->
     <script src="../../js/main.js" defer onerror="this.onerror=null;this.src='/vendor/main.js'"></script>
-    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/age-calculator/script.js'"></script>
-
+    
 
 
 
@@ -553,6 +552,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/age-calculator/script.js'"></script>
 </body>
 </html>

--- a/tools/api-key-generator/index.html
+++ b/tools/api-key-generator/index.html
@@ -295,8 +295,7 @@
     
     <!-- Scripts -->
     <script src="/js/main.js" defer onerror="this.onerror=null;this.src='/vendor/main.js'"></script>
-    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/api-key-generator/script.js'"></script>
-    
+        
     
 
 
@@ -424,6 +423,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/api-key-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/avatar-generator/index.html
+++ b/tools/avatar-generator/index.html
@@ -284,7 +284,6 @@
 
     <!-- Scripts -->
     <script src="../../js/main.js" defer onerror="this.onerror=null;this.src='/vendor/main.js'"></script>
-    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/avatar-generator/script.js'"></script>
-    <script src="script.js"></script>
+            <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/avatar-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/barcode-generator/index.html
+++ b/tools/barcode-generator/index.html
@@ -240,8 +240,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js" integrity="sha384-tOUygabpHGzWXpKv3qJM5f9tSgU6p5f4ooCayrNDwzm3/3/CDMzgHMLQZiMMGghV"></script>
     
     <!-- Custom JavaScript -->
-    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/barcode-generator/script.js'"></script>
-    <script src="/js/main.js" defer onerror="this.onerror=null;this.src='/vendor/main.js'"></script>
+        <script src="/js/main.js" defer onerror="this.onerror=null;this.src='/vendor/main.js'"></script>
 
 
 
@@ -370,6 +369,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/barcode-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/base64-encoder-decoder/index.html
+++ b/tools/base64-encoder-decoder/index.html
@@ -468,7 +468,6 @@
     
     <!-- Scripts -->
     <script src="../../js/main.js" defer onerror="this.onerror=null;this.src='/vendor/main.js'"></script>
-    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/base64-encoder-decoder/script.js'"></script>
-    <script src="script.js"></script>
+            <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/base64-encoder-decoder/script.js'"></script>
 </body>
 </html>

--- a/tools/bmi-calculator/index.html
+++ b/tools/bmi-calculator/index.html
@@ -373,7 +373,6 @@
     
     <!-- Scripts -->
     <script src="../../js/main.js" defer onerror="this.onerror=null;this.src='/vendor/main.js'"></script>
-    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/bmi-calculator/script.js'"></script>
-    <script src="script.js"></script>
+            <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/bmi-calculator/script.js'"></script>
 </body>
 </html>

--- a/tools/character-counter/index.html
+++ b/tools/character-counter/index.html
@@ -689,7 +689,7 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/character-counter/script.js'"></script>
 </body>
 </html>
 <!--

--- a/tools/code-beautifier/index.html
+++ b/tools/code-beautifier/index.html
@@ -1321,8 +1321,7 @@
     <!-- Scripts -->
     <script src="../../js/main.js"></script>
     <script src="../../vendor/js-beautify/beautify.min.js"></script>
-    <script src="script.js"></script>
-    <script>
+        <script>
         // Fix accessibility issues with lists by removing whitespace text nodes
         document.addEventListener('DOMContentLoaded', function() {
             // Fix lists structure
@@ -1620,5 +1619,6 @@
         }
     });
     </script>
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/code-beautifier/script.js'"></script>
 </body>
 </html>

--- a/tools/color-palette-generator/index.html
+++ b/tools/color-palette-generator/index.html
@@ -312,8 +312,7 @@
 
     <!-- Scripts -->
     <script src="../../vendor/bootstrap/js/bootstrap.bundle.min.js" defer></script>
-    <script src="script.js" defer></script>
-    <script>
+        <script>
         // Hide export section initially
         document.addEventListener('DOMContentLoaded', function() {
             const exportSection = document.getElementById('exportSection');
@@ -322,6 +321,6 @@
             }
         });
     </script>
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/color-palette-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/color-picker/index.html
+++ b/tools/color-picker/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/color-picker/script.js'"></script>
 </body>
 </html>

--- a/tools/css-generator/index.html
+++ b/tools/css-generator/index.html
@@ -169,6 +169,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/css-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/css-minifier/index.html
+++ b/tools/css-minifier/index.html
@@ -1336,8 +1336,7 @@ h1, h2, h3 {
 
     <!-- Scripts -->
     <script src="../../js/main.js"></script>
-    <script src="script.js"></script>
-
+    
 
 
 
@@ -1465,5 +1464,6 @@ h1, h2, h3 {
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/css-minifier/script.js'"></script>
 </body>
 </html>

--- a/tools/csv-to-json/index.html
+++ b/tools/csv-to-json/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/csv-to-json/script.js'"></script>
 </body>
 </html>

--- a/tools/currency-converter/index.html
+++ b/tools/currency-converter/index.html
@@ -635,6 +635,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/currency-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/date-format-converter/index.html
+++ b/tools/date-format-converter/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/date-format-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/email-generator/index.html
+++ b/tools/email-generator/index.html
@@ -175,6 +175,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/email-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/fake-data-generator/index.html
+++ b/tools/fake-data-generator/index.html
@@ -175,6 +175,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/fake-data-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/favicon-generator/index.html
+++ b/tools/favicon-generator/index.html
@@ -170,6 +170,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/favicon-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/gradient-generator/index.html
+++ b/tools/gradient-generator/index.html
@@ -170,6 +170,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/gradient-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/hash-generator/index.html
+++ b/tools/hash-generator/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/hash-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/hex-rgb-converter/index.html
+++ b/tools/hex-rgb-converter/index.html
@@ -875,8 +875,7 @@
 
     <!-- Scripts -->
     <script src="../../js/main.js"></script>
-    <script src="script.js"></script>
-
+    
 
 
 
@@ -1004,5 +1003,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/hex-rgb-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/html-css-js-beautifier/index.html
+++ b/tools/html-css-js-beautifier/index.html
@@ -642,6 +642,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/html-css-js-beautifier/script.js'"></script>
 </body>
 </html>

--- a/tools/html-encoder-decoder/index.html
+++ b/tools/html-encoder-decoder/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/html-encoder-decoder/script.js'"></script>
 </body>
 </html>

--- a/tools/html-minifier/index.html
+++ b/tools/html-minifier/index.html
@@ -1308,8 +1308,7 @@
 
     <!-- Scripts -->
     <script src="../../js/main.js"></script>
-    <script src="script.js"></script>
-
+    
 
 
 
@@ -1437,5 +1436,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/html-minifier/script.js'"></script>
 </body>
 </html>

--- a/tools/icon-generator/index.html
+++ b/tools/icon-generator/index.html
@@ -156,6 +156,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/icon-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/image-placeholder-generator/index.html
+++ b/tools/image-placeholder-generator/index.html
@@ -170,6 +170,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/image-placeholder-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/image-resizer/index.html
+++ b/tools/image-resizer/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/image-resizer/script.js'"></script>
 </body>
 </html>

--- a/tools/json-formatter/index.html
+++ b/tools/json-formatter/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/json-formatter/script.js'"></script>
 </body>
 </html>

--- a/tools/json-generator/index.html
+++ b/tools/json-generator/index.html
@@ -170,6 +170,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/json-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/keyword-density-checker/index.html
+++ b/tools/keyword-density-checker/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/keyword-density-checker/script.js'"></script>
 </body>
 </html>

--- a/tools/logo-generator/index.html
+++ b/tools/logo-generator/index.html
@@ -31,8 +31,7 @@
     
     
 
-    <script src="script.js"></script>
-
+    
             <script>
             // Common Tool Functionality
             document.addEventListener('DOMContentLoaded', function() {
@@ -157,5 +156,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/logo-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/lorem-ipsum-generator/index.html
+++ b/tools/lorem-ipsum-generator/index.html
@@ -1116,8 +1116,7 @@
 
     <!-- Scripts -->
     <script src="../../js/main.js"></script>
-    <script src="script.js"></script>
-
+    
 
 
 
@@ -1245,5 +1244,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/lorem-ipsum-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/markdown-to-html/index.html
+++ b/tools/markdown-to-html/index.html
@@ -1241,8 +1241,7 @@
     <!-- Prism.js for syntax highlighting -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js" integrity="sha384-MXybTpajaBV0AkcBaCPT4KIvo0FzoCiWXgcihYsw4FUkEz0Pv3JGV6tk2G8vJtDc"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha384-Uq05+JLko69eOiPr39ta9bh7kld5PKZoU+fF7g0EXTAriEollhZ+DrN8Q/Oi8J2Q"></script>
-    <script src="script.js"></script>
-
+    
 
 
 
@@ -1370,5 +1369,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/markdown-to-html/script.js'"></script>
 </body>
 </html>

--- a/tools/meta-tag-generator/index.html
+++ b/tools/meta-tag-generator/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/meta-tag-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/name-generator/index.html
+++ b/tools/name-generator/index.html
@@ -175,6 +175,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/name-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/number-base-converter/index.html
+++ b/tools/number-base-converter/index.html
@@ -745,8 +745,7 @@
 
     <!-- Scripts -->
     <script src="../../js/main.js"></script>
-    <script src="script.js"></script>
-
+    
 
 
 
@@ -874,5 +873,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/number-base-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/password-generator/index.html
+++ b/tools/password-generator/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/password-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/pdf-to-text/index.html
+++ b/tools/pdf-to-text/index.html
@@ -157,8 +157,7 @@
             });
             </script>
             
-    <script src="script.js"></script>
-</body>
+    </body>
 </html>\",
     \"description\": \"Extract text from PDF files online. Free PDF to text converter that works entirely in your browser with no uploads required.\",
     \"url\": \"/tools/pdf-to-text/\",
@@ -432,8 +431,7 @@
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"></script>
             
-    <script src="script.js"></script>
-</body>
+    </body>
 </html>",
             "item": "/tools/pdf-to-text/"
         }
@@ -614,8 +612,7 @@
             });
             </script>
             
-    <script src="script.js"></script>
-</body>
+    </body>
 </html>",
     "description": "Extract text from PDF files online. Free PDF to text converter that works entirely in your browser with no uploads required.",
     "url": "/tools/pdf-to-text/",
@@ -888,8 +885,7 @@
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"></script>
-    <script src="script.js"></script>
-
+    
 
 
 
@@ -1017,6 +1013,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/pdf-to-text/script.js'"></script>
 </body>
 </html>

--- a/tools/percentage-calculator/index.html
+++ b/tools/percentage-calculator/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/percentage-calculator/script.js'"></script>
 </body>
 </html>

--- a/tools/qr-code-generator/index.html
+++ b/tools/qr-code-generator/index.html
@@ -147,6 +147,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/qr-code-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/random-number-generator/index.html
+++ b/tools/random-number-generator/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/random-number-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/robots-txt-generator/index.html
+++ b/tools/robots-txt-generator/index.html
@@ -31,8 +31,7 @@
     
     
 
-    <script src="script.js"></script>
-
+    
             <script>
             // Common Tool Functionality
             document.addEventListener('DOMContentLoaded', function() {
@@ -157,5 +156,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/robots-txt-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/roman-numeral-converter/index.html
+++ b/tools/roman-numeral-converter/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/roman-numeral-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/seo-analyzer/index.html
+++ b/tools/seo-analyzer/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/seo-analyzer/script.js'"></script>
 </body>
 </html>

--- a/tools/serp-preview/index.html
+++ b/tools/serp-preview/index.html
@@ -31,8 +31,7 @@
     
     
 
-    <script src="script.js"></script>
-
+    
             <script>
             // Common Tool Functionality
             document.addEventListener('DOMContentLoaded', function() {
@@ -157,5 +156,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/serp-preview/script.js'"></script>
 </body>
 </html>

--- a/tools/sitemap-generator/index.html
+++ b/tools/sitemap-generator/index.html
@@ -31,8 +31,7 @@
     
     
 
-    <script src="script.js"></script>
-
+    
             <script>
             // Common Tool Functionality
             document.addEventListener('DOMContentLoaded', function() {
@@ -157,5 +156,6 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/sitemap-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/slug-generator/index.html
+++ b/tools/slug-generator/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/slug-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/text-case-converter/index.html
+++ b/tools/text-case-converter/index.html
@@ -650,7 +650,7 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/text-case-converter/script.js'"></script>
 </body>
 </html>
 

--- a/tools/text-to-speech/index.html
+++ b/tools/text-to-speech/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/text-to-speech/script.js'"></script>
 </body>
 </html>

--- a/tools/timestamp-converter/index.html
+++ b/tools/timestamp-converter/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/timestamp-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/timezone-converter/index.html
+++ b/tools/timezone-converter/index.html
@@ -798,6 +798,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/timezone-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/unicode-converter/index.html
+++ b/tools/unicode-converter/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/unicode-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/unit-converter/index.html
+++ b/tools/unit-converter/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/unit-converter/script.js'"></script>
 </body>
 </html>

--- a/tools/url-encoder-decoder/index.html
+++ b/tools/url-encoder-decoder/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/url-encoder-decoder/script.js'"></script>
 </body>
 </html>

--- a/tools/uuid-generator/index.html
+++ b/tools/uuid-generator/index.html
@@ -144,6 +144,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/uuid-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/wifi-qr-generator/index.html
+++ b/tools/wifi-qr-generator/index.html
@@ -175,6 +175,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/wifi-qr-generator/script.js'"></script>
 </body>
 </html>

--- a/tools/word-counter/index.html
+++ b/tools/word-counter/index.html
@@ -437,8 +437,7 @@
     <script src="../../js/main.js"></script>
     
     <!-- Word Counter Specific Script -->
-    <script src="script.js"></script>
-            <script>
+                <script>
             // Common Tool Functionality
             document.addEventListener('DOMContentLoaded', function() {
                 // Add ARIA labels to buttons and inputs
@@ -562,6 +561,7 @@
             });
             </script>
             
+    <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/word-counter/script.js'"></script>
 </body>
 </html>
 

--- a/tools/xml-to-json/index.html
+++ b/tools/xml-to-json/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/xml-to-json/script.js'"></script>
 </body>
 </html>

--- a/tools/yaml-to-json/index.html
+++ b/tools/yaml-to-json/index.html
@@ -166,6 +166,6 @@
             });
             </script>
             
-    <script src="script.js"></script>
+        <script src="script.js" defer onerror="this.onerror=null;this.src='/tools/yaml-to-json/script.js'"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enforce one `script.js` tag at the end of each tool page
- load scripts with `defer` and fallback path
- update tests for new script tag style
- document cleanup in verification notes

## Testing
- `./project-doctor.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857770d76b08321b42a3a1e707ab0c5